### PR TITLE
Fix error when an event's end date is not set (ongoing event)

### DIFF
--- a/PokeOneWeb/Frontend/pokeoneweb/src/app/core/components/spawn-list/spawn-list.component.ts
+++ b/PokeOneWeb/Frontend/pokeoneweb/src/app/core/components/spawn-list/spawn-list.component.ts
@@ -100,6 +100,11 @@ export class SpawnListComponent implements OnInit {
 
     private isSpawnAvailable(spawn: ISpawnModel) {
         if (spawn.isEvent) {
+            // If end date is not set, event is still open.
+            if (!spawn.eventEndDate) {
+                return true;
+            }
+
             //Source https://stackoverflow.com/a/16080662
             const todaysDate = this.dateService.getTodaysDate().split('/');
             const eventStartDate = this.dateService.convertDate(spawn.eventStartDate).split('/');


### PR DESCRIPTION
# Checklist
- [ ] [Quality Gates](https://sonarcloud.io/organizations/poke-one-web/projects) passed
- [x] Tested in an end to end manner
- [ ] Acceptance criterias according to [Jira](https://pokeoneweb.atlassian.net/jira/software/projects/POK/boards/1/backlog) are fulfilled
- [ ] Unit- & Acceptance tests written
- [ ] Documentation is updated
